### PR TITLE
add TOML support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@ltd/j-toml": "^1.38.0",
         "ajv": "^8.17.1",
         "commander": "^12.1.0",
         "lodash.merge": "^4.6.2",
@@ -2478,6 +2479,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@ltd/j-toml": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@ltd/j-toml/-/j-toml-1.38.0.tgz",
+      "integrity": "sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8931,6 +8937,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "@ltd/j-toml": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@ltd/j-toml/-/j-toml-1.38.0.tgz",
+      "integrity": "sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
+    "@ltd/j-toml": "^1.38.0",
     "ajv": "^8.17.1",
     "commander": "^12.1.0",
     "lodash.merge": "^4.6.2",

--- a/src/file-handler/index.ts
+++ b/src/file-handler/index.ts
@@ -2,15 +2,48 @@ import {ConfigVersionDocument} from '../types/config-version-document';
 import path = require('path');
 import {readFileSync} from 'fs';
 import {parse} from 'yaml';
+import TOML from '@ltd/j-toml';
 
 export class FileHandler {
   // TODO consider if this should be moved elsewhere
   extractVersionFromFilename(filename: string): string {
-    return path.basename(filename).replace('.yaml', '').replace('.yml', '');
+    return path.basename(filename).replace('.yaml', '').replace('.yml', '').replace('.toml', '');
+  }
+
+  loadDocument(filename: string): ConfigVersionDocument {
+    const ext = path.extname(filename);
+    switch (ext) {
+      case '.yaml':
+        return this.loadYaml(filename);
+      case '.yml':
+        return this.loadYaml(filename);
+      case '.toml':
+        return this.loadToml(filename);
+      default:
+        throw new Error(`Invalid extension: ${ext}`);
+    }
   }
 
   loadYaml(filename: string): ConfigVersionDocument {
     const file = readFileSync(filename, 'utf-8');
     return parse(file);
+  }
+
+  loadToml(filename: string): ConfigVersionDocument {
+    // enable parsing of multiline inline tables
+    const opts = {
+      x: {
+        multi: true,
+      },
+    };
+
+    const file = readFileSync(filename, 'utf-8');
+
+    // there is some strangeness that needs further investigation
+    // where what comes out of TOML.parse, whilst serializing to an
+    // identical JSON object as yaml.load, behaves differently when
+    // subjected to lodash.merge. the workaround is to serialize
+    // to JSON and then parse back to an object
+    return JSON.parse(JSON.stringify(TOML.parse(file, opts))) as unknown as ConfigVersionDocument;
   }
 }

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -61,7 +61,7 @@ export class ValidateOperation extends Operation<VersionDocumentParams> {
   }
 
   run(): void {
-    const versionDocument = this.fileHandler.loadYaml(this.params.filename);
+    const versionDocument = this.fileHandler.loadDocument(this.params.filename);
     const versionString = this.fileHandler.extractVersionFromFilename(this.params.filename);
     const result = this.cvdValidator.validate({
       versionString,
@@ -85,7 +85,7 @@ export class GenerateOperation extends Operation<VersionDocumentParams> {
   }
 
   run(): void {
-    const versionDocument = this.fileHandler.loadYaml(this.params.filename);
+    const versionDocument = this.fileHandler.loadDocument(this.params.filename);
     const output = this.transformer.transform(versionDocument);
     console.log(JSON.stringify(output, null, 2));
   }

--- a/test/file-handler/file-handler.test.ts
+++ b/test/file-handler/file-handler.test.ts
@@ -15,6 +15,12 @@ describe('FileHandler#extractVersionFromFilename', () => {
     expect(res).toEqual('7.6.1');
   });
 
+  it('also works with toml', () => {
+    const filename = '/path/to/file/7.6.1.toml';
+    const res = fileHandler.extractVersionFromFilename(filename);
+    expect(res).toEqual('7.6.1');
+  });
+
   it('extracts a version number with additional details from a filename', () => {
     const filename = '/path/to/file/7.6.1+rc2.yaml';
     const res = fileHandler.extractVersionFromFilename(filename);

--- a/test/processor.test.ts
+++ b/test/processor.test.ts
@@ -31,7 +31,7 @@ describe('ValidateOperation', () => {
 
   it('completes without error when config is valid', () => {
     when(fileHandler.extractVersionFromFilename(dummyFilename)).thenReturn('0.1.2');
-    when(fileHandler.loadYaml(dummyFilename)).thenReturn(ConfigVersionDocument.VALID);
+    when(fileHandler.loadDocument(dummyFilename)).thenReturn(ConfigVersionDocument.VALID);
     when(cvdValidator.validate(anything())).thenReturn(new ValidationResult());
     op.run();
     verify(cvdValidator.validate(anything())).once();
@@ -41,7 +41,7 @@ describe('ValidateOperation', () => {
     const invalidConfigResult = new ValidationResult();
     invalidConfigResult.putError('config is actually a banana');
     when(fileHandler.extractVersionFromFilename(dummyFilename)).thenReturn('0.1.2');
-    when(fileHandler.loadYaml(dummyFilename)).thenReturn(ConfigVersionDocument.VALID);
+    when(fileHandler.loadDocument(dummyFilename)).thenReturn(ConfigVersionDocument.VALID);
     when(cvdValidator.validate(anything())).thenReturn(invalidConfigResult);
     expect(() => {
       op.run();
@@ -64,7 +64,7 @@ describe('GenerateOperation', () => {
   });
 
   it('calls transform with the correct object', () => {
-    when(fileHandler.loadYaml(dummyFilename)).thenReturn(ConfigVersionDocument.VALID);
+    when(fileHandler.loadDocument(dummyFilename)).thenReturn(ConfigVersionDocument.VALID);
     when(transformer.transform(ConfigVersionDocument.VALID)).thenReturn({});
     op.run();
     verify(transformer.transform(ConfigVersionDocument.VALID)).once();

--- a/versions/appinfo/0.0.1.toml
+++ b/versions/appinfo/0.0.1.toml
@@ -1,0 +1,31 @@
+[metadata]
+configVersion = "0.0.1"
+
+[environments]
+bananas = { }
+
+[environments.default.android]
+platform = "Android"
+available = true
+minimumVersion = "1.0.0"
+recommendedVersion = "1.2.0"
+releaseFlags = {
+  featureOne = true
+  featureTwo = false
+}
+
+[environments.default.ios]
+platform = "iOS"
+available = true
+minimumVersion = "2.0.1"
+recommendedVersion = "2.2.0"
+someOtherProperty = "fish chips beans"
+releaseFlags = {
+  featureOne = true
+  featureTwo = true
+}
+
+[environments.production.android]
+releaseFlags = {
+  featureOne = false
+}

--- a/versions/appinfo/0.0.3.toml
+++ b/versions/appinfo/0.0.3.toml
@@ -1,0 +1,31 @@
+[metadata]
+configVersion = "0.0.3"
+
+[environments]
+bananas = { }
+
+[environments.default.android]
+platform = "Android"
+available = true
+minimumVersion = "1.0.0"
+recommendedVersion = "1.2.0"
+releaseFlags = {
+    featureOne = true
+    featureTwo = false
+}
+
+[environments.default.ios]
+platform = "iOS"
+available = true
+minimumVersion = "2.0.1"
+recommendedVersion = "2.2.0"
+someOtherProperty = "fish chips beans"
+releaseFlags = {
+    featureOne = true
+    featureTwo = true
+}
+
+[environments.production.android]
+releaseFlags = {
+    featureOne = false
+}


### PR DESCRIPTION
Just an example showing how TOML support could work, not suggesting we merge this as-is.

There's a really weird bug that I'm trying to understand where the behaviour of TOML and YAML documents is different when the output object gets built. Specifically, where we're performing the `merge`, deeply(ish)-nested objects (the concrete example is `releaseFlags` but could be anything) appear to be overwritten rather than merged.

The strange thing is that the intermediary representation (i.e. the JavaScript object, conforming to `ConfigVersionDocument`, emitted from the `fileHandler.loadDocument` function) is _**identical**_ for each format. If I do a `JSON.stringify` they `===` each other. It's also extremely hard to reproduce in a unit test because if I take that JSON representation and pass it as input to `Transformer.transform`, it passes all the tests every time.

So I've put in a temporary workaround just to move this along, whereby I'm serialising said object to JSON and then back again, and that seems to work - I can't see any logical reason why that should be the case so some serious digging is needed.

But let me know thoughts!