### PR TITLE
switch to int account when deploying config

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,13 +14,19 @@ jobs:
       uses: actions/setup-node@v4
     - name: Install dependencies
       run: npm ci
-    - name: Configure AWS credentials
+    - name: Configure AWS credentials for KMS (Production)
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: "arn:aws:iam::172025368201:role/github_action_mobile_backend_sign_deploy"
-        role-session-name: gha-sign-deploy-mobile-backend-config
+        role-session-name: gha-sign-mobile-backend-config
         aws-region: eu-west-1
     - name: Build config for integration
       run: npm start build -- integration --key-id alias/config-signing-key
+    - name: Configure AWS credentials for S3 (Integration)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: "arn:aws:iam::210287912431:role/github_action_mobile_backend_sign_deploy"
+        role-session-name: gha-deploy-mobile-backend-config
+        aws-region: eu-west-1
     - name: Deploy config to S3
       run: aws s3 sync ./config.out s3://govuk-app-remote-config-integration


### PR DESCRIPTION
I think this might be the key to why the job keeps on failing with `AccessDenied` - we've been using the Production role to access the single KMS key which is located in the Prod account. When we try and use that same role to then upload the config to the S3 bucket in integration, it fails. Which makes perfect sense. This change is to set up the GitHub Action to assume the Integration role before performing the `s3 sync`