### PR TITLE
Sign every file and put signature in header

### DIFF
--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -21,14 +21,20 @@ jobs:
         role-session-name: gha-sign-mobile-backend-config
         aws-region: eu-west-1
     - name: Build config for integration
-      run: npm start build -- integration --key-id alias/config-signing-key
+      run: npm start build -- integration --key-id alias/config-signing-key --output-directory ./config
+    - name: Generate signatures for config
+      run: find config -type f | xargs tools/create-signature.sh
+    - name: Generate signatures for static JSON
+      run: find static -type f | xargs tools/create-signature.sh
     - name: Configure AWS credentials for S3 (Integration)
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: "arn:aws:iam::210287912431:role/github_action_mobile_backend_sign_deploy"
         role-session-name: gha-deploy-mobile-backend-config
         aws-region: eu-west-1
+    - name: Set bucket name
+      run: export BUCKET_NAME=govuk-app-remote-config-integration
     - name: Deploy config to S3
-      run: aws s3 sync ./config.out s3://govuk-app-remote-config-integration --content-type application/json
+      run: find config -type f | xargs tools/deploy-signed-json.sh
     - name: Deploy static JSON to S3
-      run: aws s3 sync ./static s3://govuk-app-remote-config-integration/static --content-type application/json
+      run: find static -type f | xargs tools/deploy-signed-json.sh

--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -22,10 +22,8 @@ jobs:
         aws-region: eu-west-1
     - name: Build config for integration
       run: npm start build -- integration --key-id alias/config-signing-key --output-directory ./config
-    - name: Generate signatures for config
-      run: find config -type f | xargs tools/create-signature.sh
-    - name: Generate signatures for static JSON
-      run: find static -type f | xargs tools/create-signature.sh
+    - name: Generate signatures
+      run: find config static -type f | xargs tools/create-signature.sh
     - name: Configure AWS credentials for S3 (Integration)
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -34,7 +32,5 @@ jobs:
         aws-region: eu-west-1
     - name: Set bucket name
       run: export BUCKET_NAME=govuk-app-remote-config-integration
-    - name: Deploy config to S3
-      run: find config -type f | xargs tools/deploy-signed-json.sh
-    - name: Deploy static JSON to S3
-      run: find static -type f | xargs tools/deploy-signed-json.sh
+    - name: Deploy to S3
+      run: find config static -type f | xargs tools/deploy-signed-json.sh

--- a/tools/create-signature.sh
+++ b/tools/create-signature.sh
@@ -1,0 +1,23 @@
+#!/bin/dash
+set -eu
+
+for file in "$@"; do
+    # create required dirs
+    mkdir -p $(dirname "/tmp/digests/$file")
+    mkdir -p $(dirname "/tmp/signatures/$file")
+
+    # create message digest - needed to support files larger than 4096 bytes
+    openssl dgst -sha256 -binary "$file" > "/tmp/digests/$file"
+
+    # sign using KMS - pass in digest created above
+    aws kms sign \
+    --key-id alias/config-signing-key \
+    --signing-algorithm ECDSA_SHA_256 \
+    --message "fileb:///tmp/digests/$file" \
+    --message-type DIGEST \
+    --output text \
+    --query Signature | base64 --decode > "/tmp/signatures/$file"
+
+    # clean up digest file
+    rm "/tmp/digests/$file"
+done

--- a/tools/deploy-signed-json.sh
+++ b/tools/deploy-signed-json.sh
@@ -1,0 +1,15 @@
+#!/bin/dash
+set -eu
+
+for file in "$@"; do
+    signature=$(cat "/tmp/signatures/$file" | base64)
+    
+    # upload to S3
+    aws s3 cp \
+    "$file" "s3://$BUCKET_NAME/$file" \
+    --content-type application/json \
+    --metadata "govuk-sig=$signature"
+
+    # clean up signature file
+    rm "/tmp/signatures/$file"
+done


### PR DESCRIPTION
_This should be a non-breaking change as (for the time being) signatures will still be generated and embedded in the config objects themselves._

This PR seeks to address the following issues:
1. Currently the approach is to put the signature for the config as part of the response itself. The client application then needs to a) parse the JSON, b) extract the signature, c) re-stringify the config object as JSON, d) apply the verification algorithm using the stringified object as the message. The issue is that ordering of keys in a JSON object is non-deterministic, so different clients could end up with different messages for signature verification, meaning they would fail what should be valid config
2. The existing approach does not extend to static files which are generated without signatures

So the approach we are exploring works as follows:
1. For each file we are going to upload, generate a signature for it as part of the CI pipeline
2. When we upload each file, add the signature as a header
3. Then when the client wants to verify the authenticity of a response, they can take the entire body and extract the signature from a header, then pass both to the verification algorithm. As the body will be un-altered, there is no need to parse it at all until we are satisfied it is valid. Additionally, we can wrap this into our networking clients making calling code more straightforward.

I've tested that this approach works by using a non-production key to sign the files locally, then uploading them to the S3 bucket in integration and retrieving them from the endpoint using curl. Openssl then confirms that the signature in the header that gets returned is valid.

The header we will use is `x-amz-meta-govuk-sig` (the `x-amz-meta` prefix is required for this to be passed through).

Hopefully makes sense; give me a shout if any queries.