### PR TITLE
remove base64 encoding in GHA job

### DIFF
--- a/tools/create-signature.sh
+++ b/tools/create-signature.sh
@@ -16,7 +16,7 @@ for file in "$@"; do
     --message "fileb:///tmp/digests/$file" \
     --message-type DIGEST \
     --output text \
-    --query Signature | base64 --decode > "/tmp/signatures/$file"
+    --query Signature > "/tmp/signatures/$file"
 
     # clean up digest file
     rm "/tmp/digests/$file"

--- a/tools/deploy-signed-json.sh
+++ b/tools/deploy-signed-json.sh
@@ -2,7 +2,7 @@
 set -eu
 
 for file in "$@"; do
-    signature=$(cat "/tmp/signatures/$file" | base64)
+    signature=$(cat "/tmp/signatures/$file")
     
     # upload to S3
     aws s3 cp \


### PR DESCRIPTION
This part of the job is failing on CI but works fine locally so not sure what's going on. The error message complains about the value of the header that we're passing and prints it as b'xxx' which implies a binary value. That doesn't make sense to me because we're base64 encoding the contents of the signature file.

However, I think we can try simply storing the signature base64 encoded as it comes back from the KMS sign operation and then inserting that value as the header, rather than base64 decoding and then re-encoding.