### PR TITLE
clean up deleted files post-deploy

### DIFF
--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -38,3 +38,7 @@ jobs:
         aws-region: eu-west-1
     - name: Deploy to S3
       run: find config static -type f | xargs tools/deploy-signed-json.sh
+    - name: Clean up deleted files - config
+      run: aws s3 sync --delete config "s3://$BUCKET_NAME/config"
+    - name: Clean up deleted files - static
+      run: aws s3 sync --delete static "s3://$BUCKET_NAME/static"

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -30,3 +30,7 @@ jobs:
       run: find config static -type f | xargs tools/create-signature.sh
     - name: Deploy to S3
       run: find config static -type f | xargs tools/deploy-signed-json.sh
+    - name: Clean up deleted files - config
+      run: aws s3 sync --delete config "s3://$BUCKET_NAME/config"
+    - name: Clean up deleted files - static
+      run: aws s3 sync --delete static "s3://$BUCKET_NAME/static"


### PR DESCRIPTION
this PR adds a build step to the deploy pipeline which will remove any files that are no longer needed from the S3 bucket. as an example, there are 8 files currently in the integration s3 bucket which are no longer needed (mostly because the topics have been renamed). the current job does not remove extraneous files when it performs a deployment.

i've tested that this works by creating a new testing folder within the bucket with two files in, each having metadata representing the signature. i then removed one, and performed the `sync --delete` operation. this works as intended, deleting the file that is no longer present, but not overwriting the other (i.e. preserving its metadata).

i've implemented this by calling `sync` twice, once for each top-level folder that we use. you could probably find a way to DRY this up, but i think it would come at the expense of some cryptic bash scriptery that is probably less readable and maintainable. if we were to add a third location or file type in future we might want to re-visit it but i think this is fine for now.

as for why this can't be done with one overarching sync operation that both uploads and deletes, this is because each item needs to be uploaded with its own metadata (the signature) and AFAIK there isn't a way to have different metadata for each object in a sync operation.