### PR TITLE
[GOVUKAPP-1491] Add authentication issuer url

### DIFF
--- a/versions/appinfo/0.0.9.toml
+++ b/versions/appinfo/0.0.9.toml
@@ -1,0 +1,36 @@
+[metadata]
+configVersion = "0.0.9"
+
+[environments]
+production = { }
+integration = { }
+
+[environments.default.android]
+platform = "Android"
+available = true
+minimumVersion = "0.0.1"
+recommendedVersion = "0.0.1"
+searchApiUrl = "https://search.publishing.service.gov.uk/v0_1/search.json"
+authenticationIssuerBaseUrl = "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_fIJ6F25Zh"
+releaseFlags = {
+    onboarding = true
+    search = true
+    topics = true
+    recentActivity = true
+    localServices = true
+}
+
+[environments.default.ios]
+platform = "iOS"
+available = true
+minimumVersion = "0.0.1"
+recommendedVersion = "0.0.1"
+searchApiUrl = "https://search.publishing.service.gov.uk/v0_1/search.json"
+authenticationIssuerBaseUrl = "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_fIJ6F25Zh"
+releaseFlags = {
+    onboarding = true
+    search = true
+    topics = true
+    recentActivity = true
+    localServices = true
+}


### PR DESCRIPTION
Will be pulled into the app for OID config, currently residing at [1].

[1]: https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_fIJ6F25Zh/.well-known/openid-configuration