### PR TITLE
Govukapp-3597: test flex flag off

### DIFF
--- a/versions/appinfo/0.0.61.toml
+++ b/versions/appinfo/0.0.61.toml
@@ -1,0 +1,126 @@
+[metadata]
+configVersion = "0.0.60"
+
+[environments.production.ios]
+chatPollIntervalSeconds = 1
+releaseFlags = {
+    chat = true
+    localServices = true
+    notifications = true
+    onboarding = true
+    recentActivity = true
+    search = true
+    topics = true
+    profile = true
+}
+
+[environments.production.android]
+releaseFlags = {
+    chat = true
+    localServices = true
+    notifications = true
+    onboarding = true
+    recentActivity = true
+    search = true
+    topics = true
+    profile = true
+}
+
+[environments.integration.ios]
+chatPollIntervalSeconds = 1
+refreshTokenExpirySeconds = 604800
+releaseFlags = {
+    chat = true
+    localServices = true
+    notifications = true
+    onboarding = true
+    recentActivity = true
+    search = true
+    topics = true
+    profile = true
+}
+
+[environments.integration.android]
+refreshTokenExpirySeconds = 604800
+releaseFlags = {
+    chat = true
+    localServices = true
+    notifications = true
+    onboarding = true
+    recentActivity = true
+    search = true
+    topics = true
+    profile = true
+}
+
+[environments.default.android]
+platform = "Android"
+available = true
+minimumVersion = "0.0.1"
+recommendedVersion = "0.0.1"
+searchApiUrl = "https://search.publishing.service.gov.uk/v0_1/search.json"
+refreshTokenExpirySeconds = 31532400
+chatPollIntervalSeconds = 3
+chatUrls = {
+    termsAndConditions = "https://www.gov.uk/guidance/govuk-chat-terms-and-conditions"
+    privacyNotice = "https://www.gov.uk/government/publications/govuk-chat-privacy-notice"
+    about = "https://www.gov.uk/guidance/about-govuk-chat"
+    feedback = "https://www.gov.uk/contact/govuk-app/leave-feedback-about-govuk-chat"
+}
+userFeedbackBanner = {
+    body = "Tell us what you think about the app"
+    link = {
+        title = "Give feedback"
+        url = "https://www.gov.uk/contact/govuk-app"
+    }
+}
+termsAndConditions = {
+    lastUpdated = "2025-03-18T00:00:00Z",
+    url = "https://www.gov.uk/guidance/govuk-app-terms-and-conditions",
+    contentItemApiUrl = "https://www.gov.uk/api/content/guidance/govuk-app-terms-and-conditions"
+}
+chatBanner_v2 = {
+    id = "govuk_chat_banner_01_2026"
+    title = "Introducing GOV.UK Chat"
+    body = "An experimental AI tool for finding quick answers"
+    link = {
+        title = "Ask a question"
+        url = "govuk://gov.uk/chat"
+    }
+}
+
+[environments.default.ios]
+platform = "iOS"
+available = true
+minimumVersion = "0.0.1"
+recommendedVersion = "0.0.1"
+searchApiUrl = "https://search.publishing.service.gov.uk/v0_1/search.json"
+refreshTokenExpirySeconds = 31532400
+chatPollIntervalSeconds = 0.5
+chatUrls = {
+    termsAndConditions = "https://www.gov.uk/guidance/govuk-chat-terms-and-conditions"
+    privacyNotice = "https://www.gov.uk/government/publications/govuk-chat-privacy-notice"
+    about = "https://www.gov.uk/guidance/about-govuk-chat"
+    feedback = "https://www.gov.uk/contact/govuk-app/leave-feedback-about-govuk-chat"
+}
+userFeedbackBanner = {
+    body = "Tell us what you think about the app"
+    link = {
+        title = "Give feedback"
+        url = "https://www.gov.uk/contact/govuk-app"
+    }
+}
+termsAndConditions = {
+    lastUpdated = "2025-03-18T00:00:00Z",
+    url = "https://www.gov.uk/guidance/govuk-app-terms-and-conditions",
+    contentItemApiPath = "/api/content/guidance/govuk-app-terms-and-conditions"
+}
+chatBanner_v2 = {
+    id = "govuk_chat_banner_01_2026"
+    title = "Introducing GOV.UK Chat"
+    body = "An experimental AI tool for finding quick answers"
+    link = {
+        title = "Ask a question"
+        url = "govuk://gov.uk/chat"
+    }
+}

--- a/versions/appinfo/0.0.61.toml
+++ b/versions/appinfo/0.0.61.toml
@@ -1,5 +1,5 @@
 [metadata]
-configVersion = "0.0.60"
+configVersion = "0.0.61"
 
 [environments.production.ios]
 chatPollIntervalSeconds = 1
@@ -11,7 +11,7 @@ releaseFlags = {
     recentActivity = true
     search = true
     topics = true
-    profile = true
+    profile = false
 }
 
 [environments.production.android]
@@ -23,7 +23,7 @@ releaseFlags = {
     recentActivity = true
     search = true
     topics = true
-    profile = true
+    profile = false
 }
 
 [environments.integration.ios]


### PR DESCRIPTION
Turn off `profile` flag in production on iOS and Android.  This is to validate that the flag works

Ticket: [GOVUKAPP-3597](https://govukverify.atlassian.net/browse/GOVUKAPP-3597)

[GOVUKAPP-3597]: https://govukverify.atlassian.net/browse/GOVUKAPP-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ