### PR TITLE
GOVUKAPP-3677 : Automate the URL to Topics mapping file update process

### DIFF
--- a/.github/workflows/deploy-integration.yaml
+++ b/.github/workflows/deploy-integration.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin to 4.2.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pin to 6.0.3
     - name: Setup Node.js
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # pin to 4.1.0
     - name: Install dependencies

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin to 4.2.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pin to 6.0.3
     - name: Setup Node.js
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # pin to 4.1.0
     - name: Install dependencies

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin to 4.2.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pin to 6.0.3
     - name: Setup Node.js
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # pin to 4.1.0
     - name: Install dependencies

--- a/.github/workflows/update-url-to-topics-mapping.yaml
+++ b/.github/workflows/update-url-to-topics-mapping.yaml
@@ -1,0 +1,47 @@
+name: Update URL to topics mapping
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'static/topics/*'
+      - '!static/topics/list'
+      - '!static/topics/url-to-topic-mapping'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-url-to-topic-mapping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin to 4.2.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # pin to 4.1.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update URL to topics mapping
+        run: npm run start
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git add static/topics/url-to-topic-mapping
+
+          if ! git diff --cached --quiet; then
+            echo "Changes detected, pushing to main branch..."
+            git commit -m "Update URL to topics mapping" || echo "No changes to commit"
+            git push origin HEAD:${{ github.head_ref }}
+          else
+            echo "No changes detected, skipping push."
+          fi

--- a/.github/workflows/update-url-to-topics-mapping.yaml
+++ b/.github/workflows/update-url-to-topics-mapping.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin to 4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pin to 6.0.3
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -4,7 +4,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin to 4.2.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pin to 6.0.3
     - name: Setup Node.js
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # pin to 4.1.0
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm start build -- "[options]" "<environment>"
 # to generate an output tree using the 'dummydata' directory
 npm start build -- production --input-directory ./dummydata
 
-# update the URL to topics mapping document
+# to manually update the URL to topics mapping file
 npm start create-mapping
 ```
 

--- a/src/url-to-topic-mapper.ts
+++ b/src/url-to-topic-mapper.ts
@@ -51,26 +51,6 @@ function createUrlToTopicMapping() {
 
   const outputPath = path.join(topicsDir, outputFilename);
   fs.writeFileSync(outputPath, JSON.stringify(mapping, null, 2), 'utf-8');
-
-  exec(`git diff ${outputPath}`, (err: any, stdout: string, stderr: string) => {
-    if (err) {
-      console.error(`Error executing command: ${err}`);
-      return;
-    }
-
-    if (stderr) {
-      console.error(`Error output: ${stderr}`);
-      return;
-    }
-
-    if (stdout) {
-      console.log(
-        'URL to Topic mapping file has been updated. Remember to commit, push and merge these changes!'
-      );
-    } else {
-      console.log('URL to Topic mapping file is up to date. No changes detected.');
-    }
-  });
 }
 
 module.exports = {


### PR DESCRIPTION
Changes to any of the Topics files may also require the [URL to Topics mapping file](https://github.com/alphagov/govuk-mobile-backend-config/pull/150) to be updated. Currently, this is a manual process that relies on the approving developer to run a script and commit any changes made back to the PR, so that the mapping file is in-sync with the Topics content, before merging.

This change automates that additional developer step. Now, when the content team make changes to the Topics files and raise a Pull Request - a GitHub Workflow will automatically run the URL to topic mapping script and any changes made will be automatically committed back into the original PR.

This means the approving developer does not need to run the task manually, commit etc - then seek a second approval. It is already done, so they can just handle the PR as they normally would.

The workflow only checks the `static/topics` directory - so PR's for other parts of the repo are ignored. It also ignores the `list` file (which is of interest in the mapping process) and the `url-to-topic-mapping` file itself (to stop cyclic issues).

There are two consequences of this process:

- when changes are made to the mapping file and the PR updated - the Workflow is run a second time
- when the Workflow commits it's changes, it may require developer authorisation.

## Jira

- [GOVUKAPP-3677](https://govukverify.atlassian.net/browse/GOVUKAPP-3677)

[GOVUKAPP-3677]: https://govukverify.atlassian.net/browse/GOVUKAPP-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ