### PR TITLE
GOVUKAPP-3672 Dvla licence urls

### DIFF
--- a/versions/appinfo/0.0.70.toml
+++ b/versions/appinfo/0.0.70.toml
@@ -1,0 +1,146 @@
+[metadata]
+configVersion = "0.0.69"
+
+[environments.production.ios]
+chatPollIntervalSeconds = 1
+releaseFlags = {
+    chat = true
+    localServices = true
+    notifications = true
+    onboarding = true
+    recentActivity = true
+    search = true
+    topics = true
+    profile_v2 = true
+}
+
+[environments.production.android]
+releaseFlags = {
+    chat = true
+    localServices = true
+    notifications = true
+    onboarding = true
+    recentActivity = true
+    search = true
+    topics = true
+    profile_v2 = true
+}
+
+[environments.integration.ios]
+chatPollIntervalSeconds = 1
+refreshTokenExpirySeconds = 604800
+releaseFlags = {
+    chat = true
+    localServices = true
+    notifications = true
+    onboarding = true
+    recentActivity = true
+    search = true
+    topics = true
+    profile_v2 = true
+}
+
+[environments.integration.android]
+refreshTokenExpirySeconds = 604800
+releaseFlags = {
+    chat = true
+    localServices = true
+    notifications = true
+    onboarding = true
+    recentActivity = true
+    search = true
+    topics = true
+    profile_v2 = true
+}
+
+[environments.default.android]
+platform = "Android"
+available = true
+minimumVersion = "0.0.1"
+recommendedVersion = "0.0.1"
+searchApiUrl = "https://search.publishing.service.gov.uk/v0_1/search.json"
+refreshTokenExpirySeconds = 31532400
+chatPollIntervalSeconds = 3
+chatUrls = {
+    termsAndConditions = "https://www.gov.uk/guidance/govuk-chat-terms-and-conditions"
+    privacyNotice = "https://www.gov.uk/government/publications/govuk-chat-privacy-notice"
+    about = "https://www.gov.uk/guidance/about-govuk-chat"
+    feedback = "https://www.gov.uk/contact/govuk-app/leave-feedback-about-govuk-chat"
+}
+userFeedbackBanner = {
+    body = "Tell us what you think about the app"
+    link = {
+        title = "Give feedback"
+        url = "https://www.gov.uk/contact/govuk-app"
+    }
+}
+termsAndConditions = {
+    lastUpdated = "2025-03-18T00:00:00Z",
+    url = "https://www.gov.uk/guidance/govuk-app-terms-and-conditions",
+    contentItemApiUrl = "https://www.gov.uk/api/content/guidance/govuk-app-terms-and-conditions"
+}
+chatBanner_v2 = {
+    id = "govuk_chat_banner_01_2026"
+    title = "Introducing GOV.UK Chat"
+    body = "An experimental AI tool for finding quick answers"
+    link = {
+        title = "Ask a question"
+        url = "govuk://gov.uk/chat"
+    }
+}
+dvlaUrls = {
+    addVehicle = "https://driver-and-vehicles-account.service.gov.uk/add_vehicle"
+    renewLicence = "https://www.gov.uk/renew-driving-licence"
+    soldVehicle = "https://www.gov.uk/sold-bought-vehicle"
+    sornRules = "https://www.gov.uk/sorn-statutory-off-road-notification"
+    makeSorn = "https://www.gov.uk/make-a-sorn"
+    getLogbook = "https://www.gov.uk/vehicle-log-book"
+    changeLogbookAddress = "https://www.gov.uk/change-address-v5c"
+    cancelTax = "https://www.gov.uk/vehicle-tax-refund"
+}
+
+[environments.default.ios]
+platform = "iOS"
+available = true
+minimumVersion = "0.0.1"
+recommendedVersion = "0.0.1"
+searchApiUrl = "https://search.publishing.service.gov.uk/v0_1/search.json"
+refreshTokenExpirySeconds = 31532400
+chatPollIntervalSeconds = 0.5
+chatUrls = {
+    termsAndConditions = "https://www.gov.uk/guidance/govuk-chat-terms-and-conditions"
+    privacyNotice = "https://www.gov.uk/government/publications/govuk-chat-privacy-notice"
+    about = "https://www.gov.uk/guidance/about-govuk-chat"
+    feedback = "https://www.gov.uk/contact/govuk-app/leave-feedback-about-govuk-chat"
+}
+userFeedbackBanner = {
+    body = "Tell us what you think about the app"
+    link = {
+        title = "Give feedback"
+        url = "https://www.gov.uk/contact/govuk-app"
+    }
+}
+termsAndConditions = {
+    lastUpdated = "2025-03-18T00:00:00Z",
+    url = "https://www.gov.uk/guidance/govuk-app-terms-and-conditions",
+    contentItemApiPath = "/api/content/guidance/govuk-app-terms-and-conditions"
+}
+chatBanner_v2 = {
+    id = "govuk_chat_banner_01_2026"
+    title = "Introducing GOV.UK Chat"
+    body = "An experimental AI tool for finding quick answers"
+    link = {
+        title = "Ask a question"
+        url = "govuk://gov.uk/chat"
+    }
+}
+dvlaUrls = {
+    addVehicle = "https://driver-and-vehicles-account.service.gov.uk/add_vehicle"
+    renewLicence = "https://www.gov.uk/renew-driving-licence"
+    soldVehicle = "https://www.gov.uk/sold-bought-vehicle"
+    sornRules = "https://www.gov.uk/sorn-statutory-off-road-notification"
+    makeSorn = "https://www.gov.uk/make-a-sorn"
+    getLogbook = "https://www.gov.uk/vehicle-log-book"
+    changeLogbookAddress = "https://www.gov.uk/change-address-v5c"
+    cancelTax = "https://www.gov.uk/vehicle-tax-refund"
+}

--- a/versions/appinfo/0.0.70.toml
+++ b/versions/appinfo/0.0.70.toml
@@ -1,5 +1,5 @@
 [metadata]
-configVersion = "0.0.69"
+configVersion = "0.0.70"
 
 [environments.production.ios]
 chatPollIntervalSeconds = 1
@@ -143,4 +143,7 @@ dvlaUrls = {
     getLogbook = "https://www.gov.uk/vehicle-log-book"
     changeLogbookAddress = "https://www.gov.uk/change-address-v5c"
     cancelTax = "https://www.gov.uk/vehicle-tax-refund"
+    changeLicenceAddress = "https://www.gov.uk/change-address-driving-licence"
+    changeNameGenderLicence = "https://www.gov.uk/change-name-driving-licence"
+    replaceLicence = "https://www.gov.uk/replace-a-driving-licence"
 }


### PR DESCRIPTION
Added Dvla urls for licence view menu (urls in figma)

https://govukverify.atlassian.net/browse/GOVUKAPP-3672
[Figma designs](https://www.figma.com/design/utmaFnJPNY4sVgwjui5MmK/Driving?node-id=6711-25768&t=GJ0APH5cgaWUf5FG-1)